### PR TITLE
😁 Ash upgrade 0.37 -> 0.38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,11 +13,11 @@ dependencies = [
 
 [[package]]
 name = "ash"
-version = "0.37.3+1.3.251"
+version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
- "libloading 0.7.4",
+ "libloading",
 ]
 
 [[package]]
@@ -78,7 +78,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.8.6",
+ "libloading",
 ]
 
 [[package]]
@@ -197,16 +197,6 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
-
-[[package]]
-name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
-]
 
 [[package]]
 name = "libloading"
@@ -397,28 +387,6 @@ name = "widestring"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/crates/nvngx-sys/Cargo.toml
+++ b/crates/nvngx-sys/Cargo.toml
@@ -28,7 +28,7 @@ cc = "1"
 widestring = "1"
 libc = "0.2"
 # TODO: These are not technically "sys" crates
-ash = { version = "0.37", optional = true }
+ash = { version = "0.38", optional = true }
 windows = { version = "0.61", features = ["Win32_Graphics_Direct3D12", "Win32_Graphics_Dxgi_Common"], optional = true }
 
 [features]

--- a/crates/nvngx/Cargo.toml
+++ b/crates/nvngx/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/iddm/nvngx-rs"
 
 [dependencies]
 widestring = "1"
-ash = { version = "0.37", optional = true }
+ash = { version = "0.38", optional = true }
 log = "0.4"
 uuid = { version = "1", features = ["v4"] }
 derive_builder = "0.12"

--- a/crates/nvngx/src/vk/feature.rs
+++ b/crates/nvngx/src/vk/feature.rs
@@ -509,14 +509,12 @@ impl Feature {
         mut super_sampling_create_parameters: SuperSamplingCreateParameters,
     ) -> Result<SuperSamplingFeature> {
         let feature_type = NVSDK_NGX_Feature::NVSDK_NGX_Feature_SuperSampling;
-        let rendering_resolution = vk::Extent2D::builder()
+        let rendering_resolution = vk::Extent2D::default()
             .width(super_sampling_create_parameters.0.Feature.InWidth)
-            .height(super_sampling_create_parameters.0.Feature.InHeight)
-            .build();
-        let target_resolution = vk::Extent2D::builder()
+            .height(super_sampling_create_parameters.0.Feature.InHeight);
+        let target_resolution = vk::Extent2D::default()
             .width(super_sampling_create_parameters.0.Feature.InTargetWidth)
-            .height(super_sampling_create_parameters.0.Feature.InTargetHeight)
-            .build();
+            .height(super_sampling_create_parameters.0.Feature.InTargetHeight);
         unsafe {
             let mut handle = FeatureHandle::new();
             Result::from(nvngx_sys::HELPERS_NGX_VULKAN_CREATE_DLSS_EXT1(
@@ -560,14 +558,12 @@ impl Feature {
         mut ray_reconstruction_create_parameters: RayReconstructionCreateParameters,
     ) -> Result<RayReconstructionFeature> {
         let feature_type = NVSDK_NGX_Feature::NVSDK_NGX_Feature_RayReconstruction;
-        let rendering_resolution = vk::Extent2D::builder()
+        let rendering_resolution = vk::Extent2D::default()  
             .width(ray_reconstruction_create_parameters.0.InWidth)
-            .height(ray_reconstruction_create_parameters.0.InHeight)
-            .build();
-        let target_resolution = vk::Extent2D::builder()
+            .height(ray_reconstruction_create_parameters.0.InHeight);
+        let target_resolution = vk::Extent2D::default()
             .width(ray_reconstruction_create_parameters.0.InTargetWidth)
-            .height(ray_reconstruction_create_parameters.0.InTargetHeight)
-            .build();
+            .height(ray_reconstruction_create_parameters.0.InTargetHeight);
 
         unsafe {
             let mut handle = FeatureHandle::new();


### PR DESCRIPTION
Breda uses v-0.38 

This PR bumps the dependency and fixes the issues alongside the upgrade.