### PR TITLE
Add FeatureCommonInfo for DLL search paths and log crate callback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,7 @@ version = "0.3.1+v310.1.0"
 dependencies = [
  "ash",
  "derive_builder",
+ "libc",
  "log",
  "nvngx-sys",
  "uuid",

--- a/crates/nvngx/Cargo.toml
+++ b/crates/nvngx/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/iddm/nvngx-rs"
 [dependencies]
 widestring = "1"
 ash = "0.38"
+libc = "0.2"
 log = "0.4"
 uuid = { version = "1", features = ["v4"] }
 derive_builder = "0.12"

--- a/crates/nvngx/src/common.rs
+++ b/crates/nvngx/src/common.rs
@@ -1,0 +1,88 @@
+//! Common information provided to NGX at system initialization time.
+//!
+//! These types mirror [`nvngx_sys::NVSDK_NGX_FeatureCommonInfo`] and friends from the NGX
+//! SDK. They are API-agnostic (Vulkan / D3D12 / CUDA), though only the Vulkan
+//! path currently exposes them via [`crate::vk::System::new`].
+
+use std::ffi::CStr;
+use std::path::Path;
+
+use nvngx_sys::{NVSDK_NGX_Feature, NVSDK_NGX_Logging_Level};
+
+/// Controls how verbose NGX's own logging is.
+#[derive(Debug, Clone, Copy)]
+pub enum LoggingLevel {
+    /// Disable NGX logging.
+    Off,
+    /// Standard information and error logging.
+    On,
+    /// Verbose logging (diagnostic details).
+    Verbose,
+}
+
+impl From<LoggingLevel> for NVSDK_NGX_Logging_Level {
+    fn from(l: LoggingLevel) -> Self {
+        match l {
+            LoggingLevel::Off => Self::NVSDK_NGX_LOGGING_LEVEL_OFF,
+            LoggingLevel::On => Self::NVSDK_NGX_LOGGING_LEVEL_ON,
+            LoggingLevel::Verbose => Self::NVSDK_NGX_LOGGING_LEVEL_VERBOSE,
+        }
+    }
+}
+
+/// Opt-in routing of NGX log lines through the [`log`] crate.
+///
+/// When supplied via [`FeatureCommonInfo::logging`], every NGX log message is
+/// passed to [`log::log!`] at a level derived from the NGX level
+/// ([`LoggingLevel::Verbose`] → [`log::Level::Debug`], [`LoggingLevel::On`] →
+/// [`log::Level::Info`]). This avoids having to enable NGX's registry-based
+/// log sinks on Windows.
+#[derive(Debug, Clone, Copy)]
+pub struct LoggingConfig {
+    /// Minimum NGX severity to forward. NGX honours the *higher* of this value
+    /// and whatever is configured via the registry.
+    pub minimum_level: LoggingLevel,
+    /// When [`true`], NGX won't write to its other log sinks (files, on-screen
+    /// console). Log lines are delivered *only* through the [`log`] crate.
+    pub disable_other_sinks: bool,
+}
+
+/// Common information provided to NGX at initialization time.
+///
+/// This mirrors [`nvngx_sys::NVSDK_NGX_FeatureCommonInfo`] from the NGX SDK, exposing:
+/// - an optional list of additional search paths for feature DLLs
+///   (e.g. `nvngx_dlss.dll`), searched in descending order of preference in
+///   addition to the application folder;
+/// - an optional [`LoggingConfig`] that pipes NGX logs through the [`log`] crate.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FeatureCommonInfo<'a> {
+    /// Extra directories to search for feature DLLs, in descending order of
+    /// preference. The application folder is always searched as well.
+    pub search_paths: &'a [&'a Path],
+    /// If [`Some`], NGX logs are routed through the [`log`] crate.
+    pub logging: Option<LoggingConfig>,
+}
+
+/// Static `extern "C"` callback that pipes NGX log lines into the [`log`]
+/// crate. NGX calls this from arbitrary threads; [`log`]'s macros are
+/// thread-safe so no additional synchronization is needed.
+pub(crate) unsafe extern "C" fn log_crate_callback(
+    message: *const std::os::raw::c_char,
+    level: NVSDK_NGX_Logging_Level,
+    source: NVSDK_NGX_Feature,
+) {
+    let msg = if message.is_null() {
+        std::borrow::Cow::Borrowed("<null>")
+    } else {
+        unsafe { CStr::from_ptr(message) }.to_string_lossy()
+    };
+    let log_level = match level {
+        NVSDK_NGX_Logging_Level::NVSDK_NGX_LOGGING_LEVEL_VERBOSE => log::Level::Debug,
+        NVSDK_NGX_Logging_Level::NVSDK_NGX_LOGGING_LEVEL_ON => log::Level::Info,
+        other => {
+            log::warn!(target: "nvngx", "[{source:?}] Unrecognized NGX logging level {other:?}: {}", msg.trim_end());
+            return;
+        }
+    };
+    log::log!(target: "nvngx", log_level, "[{source:?}] {}", msg.trim_end());
+}

--- a/crates/nvngx/src/lib.rs
+++ b/crates/nvngx/src/lib.rs
@@ -2,6 +2,9 @@
 //! providing some abstractions in order to make the use easier.
 #![deny(missing_docs)]
 
+pub mod common;
+pub use common::*;
+
 pub mod vk;
 pub use vk::*;
 

--- a/crates/nvngx/src/vk/mod.rs
+++ b/crates/nvngx/src/vk/mod.rs
@@ -103,6 +103,11 @@ pub struct System {
 
 impl System {
     /// Creates a new NVIDIA NGX system.
+    ///
+    /// `common_info` carries optional feature-DLL search paths and a logging
+    /// callback configuration; pass [`None`] to preserve the NGX defaults (no
+    /// extra search paths, logging controlled by the registry on Windows).
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         project_id: Option<uuid::Uuid>,
         engine_version: &str,
@@ -111,6 +116,7 @@ impl System {
         instance: &ash::Instance,
         physical_device: vk::PhysicalDevice,
         logical_device: vk::Device,
+        common_info: Option<&crate::common::FeatureCommonInfo<'_>>,
     ) -> Result<Self> {
         let engine_type = nvngx_sys::NVSDK_NGX_EngineType::NVSDK_NGX_ENGINE_TYPE_CUSTOM;
         let project_id =
@@ -119,6 +125,54 @@ impl System {
         let engine_version = std::ffi::CString::new(engine_version).unwrap();
         let application_data_path =
             widestring::WideString::from_str(application_data_path.to_str().unwrap());
+
+        // Build `NVSDK_NGX_FeatureCommonInfo` as plain locals scoped to the
+        // FFI call below. NGX consumes the paths synchronously during
+        // `NGXInitContext` (the feature DLL is loaded inline; see breda's
+        // `nvngx.log`) and captures `LoggingInfo` into its own state, so the
+        // buffers do not need to outlive the init call.
+        let path_buffers: Vec<widestring::WideString>;
+        let path_pointers: Vec<*const libc::wchar_t>;
+        let c_common_info: nvngx_sys::NVSDK_NGX_FeatureCommonInfo;
+        let common_info_ptr: *const nvngx_sys::NVSDK_NGX_FeatureCommonInfo = match common_info {
+            None => std::ptr::null(),
+            Some(info) => {
+                path_buffers = info
+                    .search_paths
+                    .iter()
+                    .map(|p| {
+                        widestring::WideString::from_str(
+                            p.to_str().expect("NGX search paths must be valid UTF-8"),
+                        )
+                    })
+                    .collect();
+                path_pointers = path_buffers
+                    .iter()
+                    .map(|s| s.as_ptr().cast::<libc::wchar_t>())
+                    .collect();
+                c_common_info = nvngx_sys::NVSDK_NGX_FeatureCommonInfo {
+                    PathListInfo: nvngx_sys::NVSDK_NGX_PathListInfo {
+                        Path: if path_pointers.is_empty() {
+                            std::ptr::null()
+                        } else {
+                            path_pointers.as_ptr()
+                        },
+                        Length: path_pointers.len() as u32,
+                    },
+                    InternalData: std::ptr::null_mut(),
+                    LoggingInfo: match info.logging {
+                        Some(cfg) => nvngx_sys::NVSDK_NGX_LoggingInfo {
+                            LoggingCallback: Some(crate::common::log_crate_callback),
+                            MinimumLoggingLevel: cfg.minimum_level.into(),
+                            DisableOtherLoggingSinks: cfg.disable_other_sinks,
+                        },
+                        None => nvngx_sys::NVSDK_NGX_LoggingInfo::default(),
+                    },
+                };
+                &c_common_info
+            }
+        };
+
         Result::from(unsafe {
             nvngx_sys::NVSDK_NGX_VULKAN_Init_with_ProjectID(
                 project_id.as_ptr(),
@@ -130,7 +184,7 @@ impl System {
                 logical_device,
                 entry.static_fn().get_instance_proc_addr,
                 instance.fp_v1_0().get_device_proc_addr,
-                std::ptr::null(),
+                common_info_ptr,
                 nvngx_sys::NVSDK_NGX_Version::NVSDK_NGX_Version_API,
             )
         })
@@ -287,52 +341,6 @@ impl From<VkImageResourceDescription> for NVSDK_NGX_Resource_VK {
         }
     }
 }
-
-// #[derive(Debug)]
-// pub struct FeatureCommonInfo {
-//     path_list_info:,
-
-// }
-
-// /// Contains information common to all features, used by NGX in
-// /// determining requested feature availability.
-// #[derive(Debug, Clone)]
-// pub struct FeatureDiscoveryBuilder {
-//     /// API Struct version number.
-//     sdk_version: Option<bindings::NVSDK_NGX_Version>,
-//     /// Valid NVSDK_NGX_Feature enum corresponding to DLSS v3 Feature
-//     /// which is being queried for availability.
-//     feature_type: Option<bindings::NVSDK_NGX_Feature>,
-//     /// Unique Id provided by NVIDIA corresponding to a particular
-//     /// Application or alternatively custom Id set by Engine.
-//     application_identifier: Option<bindings::NVSDK_NGX_Application_Identifier>,
-//     /// Folder to store logs and other temporary files (write access
-//     /// required), normally this would be a location in Documents or
-//     /// ProgramData.
-//     application_data_path: Option<widestring::WideCString>,
-//     /// Contains information common to all features, presently only a
-//     /// list of all paths feature dlls can be located in, other than the
-//     /// default path - application directory.
-//     common_info: Option<FeatureCommonInfo>,
-// }
-
-// impl FeatureDiscoveryBuilder {
-//     /// Creates a new feature discovery builder. The created feature
-//     /// discovery builder contains blanket values.
-//     pub fn new() -> Self {
-//         Self(bindings::NVSDK_NGX_FeatureDiscoveryInfo {
-//             SDKVersion: bindings::NVSDK_NGX_Version::NVSDK_NGX_Version_API,
-//             FeatureID: bindings::NVSDK_NGX_Feature::NVSDK_NGX_Feature_Reserved_Unknown,
-
-//         })
-//     }
-
-//     /// Consumes the builder and obtains the requirements for the
-//     /// requested feature based on the information provided.
-//     pub fn get_requirements(self) -> Result<FeatureRequirement> {
-//         unimplemented!()
-//     }
-// }
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary
- `vk::System::new` now takes an `Option<&FeatureCommonInfo>`, mirroring `NVSDK_NGX_FeatureCommonInfo` from the NGX SDK
- Adds optional extra DLL search paths for feature DLLs (e.g. `nvngx_dlss.dll`)
- Adds optional `LoggingConfig` that pipes NGX log lines through the `log` crate, bypassing registry-controlled file sinks on Windows

## Test plan
- [ ] Verify `System::new` works with `None` for `common_info` (preserves existing behavior)
- [ ] Verify `System::new` works with custom search paths
- [ ] Verify `LoggingConfig` routes NGX log messages through the `log` crate

🤖 Generated with [Claude Code](https://claude.com/claude-code)