### PR TITLE
Force static linking of `nvsdk_ngx`

### DIFF
--- a/crates/nvngx-sys/build.rs
+++ b/crates/nvngx-sys/build.rs
@@ -30,12 +30,12 @@ fn main() {
             let windows_mt_suffix = windows_mt_suffix();
             // TODO select debug and/or _iterator0/1 when /MTd or /MDd are set.
             let dbg_suffix = if true { "" } else { "_dbg" };
-            println!("cargo:rustc-link-lib=nvsdk_ngx{windows_mt_suffix}{dbg_suffix}");
+            println!("cargo:rustc-link-lib=static=nvsdk_ngx{windows_mt_suffix}{dbg_suffix}");
             println!("cargo:rustc-link-search={}", link_library_path.display());
         }
         "linux" => {
             // On Linux there is only one link-library
-            println!("cargo:rustc-link-lib=nvsdk_ngx");
+            println!("cargo:rustc-link-lib=static=nvsdk_ngx");
             println!("cargo:rustc-link-lib=stdc++");
             println!("cargo:rustc-link-search={}", dlss_library_path.display());
         }


### PR DESCRIPTION
## Summary

- Use `cargo:rustc-link-lib=static=...` instead of `cargo:rustc-link-lib=...` for both Windows and Linux in the `nvngx-sys` build script

## Motivation

The DLSS SDK ships the entry point API as a **static import library** only (`libnvsdk_ngx.a` on Linux, `nvsdk_ngx_*.lib` on Windows). There is no shared library equivalent — the `.a`/`.lib` is a stub that internally `dlopen()`s the feature shared libraries (`libnvidia-ngx-dlss.so` / `nvngx_dlss.dll`) at runtime.

Without the `static=` qualifier, the linker is free to prefer a dynamic `libnvsdk_ngx.so` if one happens to be on the library search path (e.g. from a system NVIDIA driver package), which would introduce an unexpected `DT_NEEDED` entry and a hard runtime dependency on a library that may not exist on the target system.

Explicitly requesting `static` linkage ensures the symbols are always resolved from the bundled `.a`/`.lib` stub, matching the SDK's intended usage.

## Test plan

- [x] `cargo build -p nvngx-sys` succeeds on Linux
- [x] `cargo build -p nvngx-sys` succeeds on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)